### PR TITLE
refactor(lib/file): changed how ManagedObject works

### DIFF
--- a/bin/run-test
+++ b/bin/run-test
@@ -13,7 +13,7 @@ if [ "$1" = "c23b0a-hashmap_test" ]; then
 fi
 if [ "$1" = "b5824a-bptree_test" ]; then
   rm -f file.o
-  "$EXE" < lib/file/bptree_test.in | diff -w - lib/file/bptree_test.ans || exit 1
+  valgrind $VG_FLAGS "$EXE" < lib/file/bptree_test.in | diff -w - lib/file/bptree_test.ans || exit 1
   exit 0
 fi
 

--- a/lib/file/internal/file.h
+++ b/lib/file/internal/file.h
@@ -1,0 +1,49 @@
+#ifndef TICKET_LIB_FILE_INTERNAL_FILE_H_
+#define TICKET_LIB_FILE_INTERNAL_FILE_H_
+
+#include "file/file.h"
+
+namespace ticket::file::internal {
+
+template <typename T, typename Meta = Unit, size_t szChunk = kDefaultSzChunk>
+class UnmanagedObject {
+ private:
+  using File_ = File<Meta, szChunk>;
+  File_ *file_;
+  size_t id_ = -1;
+  UnmanagedObject (File_ &file, size_t id) : file_(&file), id_(id) {}
+  static size_t getSize_ () { return offsetof(T, _end) - offsetof(T, _start); }
+  static size_t getOffset_ () { return offsetof(T, _start); }
+ public:
+  UnmanagedObject () = delete;
+  UnmanagedObject (File_ &file) : file_(&file) {}
+  virtual ~UnmanagedObject () = default;
+
+  size_t id () { return id_; }
+
+  static T get (File_ &file, size_t id) {
+    char buf[sizeof(T)];
+    file.get(buf + getOffset_(), id, getSize_());
+    UnmanagedObject &result = *reinterpret_cast<UnmanagedObject *>(buf);
+    result.file_ = &file;
+    result.id_ = id;
+    return *reinterpret_cast<T *>(buf);
+  }
+  void save () {
+    if (id_ != -1) throw Exception("Already saved");
+    id_ = file_->push(reinterpret_cast<char *>(this) + getOffset_(), getSize_());
+  }
+  void update () {
+    if (id_ == -1) throw Exception("Not saved");
+    file_->set(reinterpret_cast<char *>(this) + getOffset_(), id_, getSize_());
+  }
+  void destroy () {
+    if (id_ == -1) throw Exception("Not saved");
+    file_->remove(id_);
+    id_ = -1;
+  }
+};
+
+} // namespace ticket::file::internal
+
+#endif // TICKET_LIB_FILE_INTERNAL_FILE_H_

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -5,17 +5,13 @@
 
 namespace ticket {
 
-file::File<> orders {"orders"};
-file::Index<User::Id, Order, decltype(orders)>
-  ixOrdersUserId {&Order::user, "orders.user.ix", orders};
+file::Index<User::Id, Order> Order::ixUserId
+  {&Order::user, "orders.user.ix"};
 
-file::File<> pendingOrders {"pending-orders"};
-file::Index<Ride, PendingOrder, decltype(pendingOrders)>
-  ixPendingOrdersRide {
-    &PendingOrder::ride,
-    "pending-orders.ride.ix",
-    pendingOrders
-  };
+file::Index<Ride, PendingOrder> PendingOrder::ixRide {
+  &PendingOrder::ride,
+  "pending-orders.ride.ix"
+};
 
 auto command::dispatch (const command::BuyTicket &cmd) -> void {
   // TODO

--- a/src/order.h
+++ b/src/order.h
@@ -8,7 +8,7 @@
 
 namespace ticket {
 
-struct Order : public file::ManagedObject<Order> {
+struct OrderBase {
   using Id = int;
   enum Status { kSuccess, kPending, kRefunded };
 
@@ -20,13 +20,15 @@ struct Order : public file::ManagedObject<Order> {
 
   /// gets the corresponding train object.
   auto getTrain () -> Train;
+
+  static constexpr const char *filename = "orders";
+};
+struct Order : public file::Managed<OrderBase> {
+  static file::Index<User::Id, Order> ixUserId;
 };
 
-extern file::File<> orders;
-extern file::Index<User::Id, Order, decltype(orders)>
-  ixOrdersUserId;
 
-struct PendingOrder : public file::ManagedObject<PendingOrder> {
+struct PendingOrderBase {
   Ride ride;
   int ixFrom, ixTo;
   int seats;
@@ -36,11 +38,12 @@ struct PendingOrder : public file::ManagedObject<PendingOrder> {
   auto satisfiable () -> bool;
   /// gets the corresponding order object.
   auto getOrder () -> Order;
-};
 
-extern file::File<> pendingOrders;
-extern file::Index<Ride, PendingOrder, decltype(pendingOrders)>
-  ixPendingOrdersRide;
+  static constexpr const char *filename = "pending-orders";
+};
+struct PendingOrder : public file::Managed<PendingOrderBase> {
+  static file::Index<Ride, PendingOrder> ixRide;
+};
 
 } // namespace ticket
 

--- a/src/rollback.cpp
+++ b/src/rollback.cpp
@@ -4,8 +4,6 @@
 
 namespace ticket {
 
-file::File<> logEntries {"rollback-log"};
-
 auto command::dispatch (const command::Rollback &cmd) -> void {
   // TODO
 }

--- a/src/rollback.h
+++ b/src/rollback.h
@@ -39,7 +39,7 @@ struct RefundTicket {
   Order::Status status;
 };
 
-struct LogEntry : public file::ManagedObject<LogEntry> {
+struct LogEntryBase {
   int timestamp;
   Variant<
     AddUser,
@@ -49,9 +49,10 @@ struct LogEntry : public file::ManagedObject<LogEntry> {
     BuyTicket,
     RefundTicket
   > content;
-};
 
-extern file::File<> logEntries;
+  static constexpr const char *filename = "rollback-log";
+};
+using LogEntry = file::Managed<LogEntryBase>;
 
 /**
  * @brief Visitor for the log entries.

--- a/src/train.cpp
+++ b/src/train.cpp
@@ -5,18 +5,12 @@
 
 namespace ticket {
 
-file::File<> trains {"trains"};
-file::Index<Train::Id, Train, decltype(trains)>
-  ixTrainsId {&Train::trainId, "trains.train-id.ix", trains};
-file::BpTree<size_t, int> ixTrainsStop {"trains.stop.ix"};
+file::Index<Train::Id, Train> Train::ixId
+  {&Train::trainId, "trains.train-id.ix"};
+file::BpTree<size_t, int> Train::ixStop {"trains.stop.ix"};
 
-file::File<> rideSeats {"ride-seats"};
-file::Index<Ride, RideSeats, decltype(rideSeats)>
-  ixRideSeatsRide {
-    &RideSeats::ride,
-    "ride-seats.ride.ix",
-    rideSeats
-  };
+file::Index<Ride, RideSeats> RideSeats::ixRide
+  {&RideSeats::ride, "ride-seats.ride.ix"};
 
 auto command::dispatch (const command::AddTrain &cmd) -> void {
   // TODO

--- a/src/train.h
+++ b/src/train.h
@@ -18,7 +18,7 @@ using Id = file::Varchar<30>;
 
 struct RideSeats;
 
-struct Train : public file::ManagedObject<Train> {
+struct TrainBase {
   using Id = file::Varchar<20>;
   using Type = char;
   struct Stop {
@@ -70,12 +70,14 @@ struct Train : public file::ManagedObject<Train> {
    * @param ixDeparture the index of the departing stop.
    */
   auto runsOnDate (Date date, int ixDeparture) -> bool;
+
+  static constexpr const char *filename = "trains";
+};
+struct Train : public file::Managed<TrainBase> {
+  static file::Index<Train::Id, Train> ixId;
+  static file::BpTree<size_t, int> ixStop;
 };
 
-extern file::File<> trains;
-extern file::Index<Train::Id, Train, decltype(trains)>
-  ixTrainsId;
-extern file::BpTree<size_t, int> ixTrainsStop;
 
 struct Ride {
   /// the numerical id of the train.
@@ -85,7 +87,7 @@ struct Ride {
   auto operator< (const Ride &rhs) const -> bool;
 };
 
-struct RideSeats : public file::ManagedObject<RideSeats> {
+struct RideSeatsBase {
   Ride ride;
   file::Array<int, 99> seatsRemaining;
 
@@ -95,11 +97,12 @@ struct RideSeats : public file::ManagedObject<RideSeats> {
    * @param ixTo index of the arriving stop
    */
   auto ticketsAvailable (int ixFrom, int ixTo) -> int;
-};
 
-extern file::File<> rideSeats;
-extern file::Index<Ride, RideSeats, decltype(rideSeats)>
-  ixRideSeatsRide;
+  static constexpr const char *filename = "ride-seats";
+};
+struct RideSeats : public file::Managed<RideSeatsBase> {
+  static file::Index<Ride, RideSeats> ixRide;
+};
 
 } // namespace ticket
 

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -8,14 +8,13 @@
 
 namespace ticket {
 
-file::File<> users {"users"};
-file::Index<User::Id, User, decltype(users)> ixUsersUsername
-  {&User::username, "users.username.ix", users};
+file::Index<User::Id, User> User::ixUsername
+  {&User::username, "users.username.ix"};
 
 /// a set of users that are logged in.
 HashMap<std::string, Unit> usersLoggedIn;
 
-auto User::hasUser (const char *username) -> bool {
+auto UserBase::hasUser (const char *username) -> bool {
   // TODO
 }
 

--- a/src/user.h
+++ b/src/user.h
@@ -7,7 +7,7 @@
 
 namespace ticket {
 
-struct User : public file::ManagedObject<User> {
+struct UserBase {
   using Id = file::Varchar<20>;
   using Password = file::Varchar<30>;
   using Name = file::Varchar<15>;
@@ -22,11 +22,12 @@ struct User : public file::ManagedObject<User> {
 
   /// checks if there is a user with the given username.
   static auto hasUser (const char *username) -> bool;
-};
 
-extern file::File<> users;
-extern file::Index<User::Id, User, decltype(users)>
-  ixUsersUsername;
+  static constexpr const char *filename = "users";
+};
+struct User : public file::Managed<UserBase> {
+  static file::Index<User::Id, User> ixUsername;
+};
 
 } // namespace ticket
 


### PR DESCRIPTION
ManagedObject was a CRTP originally designed to help the implementation of the B+ tree. We reused it for storing general objects. However, it has several issues:

- Every subclass of ManagedObject had to store its own file storage, and doing this requires writing `file::File<sizeof(Foo)> foos {"foos"};` over and over, which is not great.
- Furthermore, when using subclasses of ManagedObject, the caller needs to pass the file object to the API, like `Users::get(users, 1)`. It's a strange and pointless repetition.
- Efficiently storing models requires that models declare `char _start[0]` and `char _end[0]`, which aside from being a hack, is ugly.

This commit rewrote the sequential file storage subsystem to address these issues. For the purpose of not breaking B+ tree code, a copy of the original ManagedObject is made under lib/file/internal/file.h. The new API extends the user-provided base class rather than being a base class. The name ManagedObject fits in the context `Foo : public ManagedObject`, but not `Foo = ManagedObject<FooBase>`. Therefore, its name is changed to simply Managed.

The new API takes the approach of convention over configuration. You need to specify the filename in the base class under the special `static constexpr const char *filename` variable. Failure to provide this value would lead to a compile error.

Other APIs are also modified to accompany this change; notably Index, which no longer need to pass in the file object of the model, since the object needed is already innate of the model class.