### PR TITLE
chore: rename file.h to unmanaged-object.h

### DIFF
--- a/lib/file/bptree.h
+++ b/lib/file/bptree.h
@@ -6,7 +6,7 @@
 #include "algorithm.h"
 #include "file/array.h"
 #include "file/file.h"
-#include "file/internal/file.h"
+#include "file/internal/unmanaged-object.h"
 #include "file/set.h"
 #include "optional.h"
 #include "utility.h"

--- a/lib/file/internal/unmanaged-object.h
+++ b/lib/file/internal/unmanaged-object.h
@@ -1,5 +1,5 @@
-#ifndef TICKET_LIB_FILE_INTERNAL_FILE_H_
-#define TICKET_LIB_FILE_INTERNAL_FILE_H_
+#ifndef TICKET_LIB_FILE_INTERNAL_UNMANAGED_OBJECT_H_
+#define TICKET_LIB_FILE_INTERNAL_UNMANAGED_OBJECT_H_
 
 #include "file/file.h"
 
@@ -46,4 +46,4 @@ class UnmanagedObject {
 
 } // namespace ticket::file::internal
 
-#endif // TICKET_LIB_FILE_INTERNAL_FILE_H_
+#endif // TICKET_LIB_FILE_INTERNAL_UNMANAGED_OBJECT_H_


### PR DESCRIPTION
/lib/file/internal/file.h was moved to /lib/file/internal/unmanaged-object.h.
file.h #includes "file/file.h", which caused some confusion. This rename
clarifies the content of this header.