### PR TITLE
fix(rollback): store id of last block

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -81,6 +81,32 @@ User::truncate();
 User::ixUsername.truncate();
 ```
 
+### Using file metadata objects
+
+Metadata is a small block of storage at the beginning of a
+file. You can use this block to store a chunk of
+constant-sized data.
+
+For example, if we have:
+
+```cpp
+struct LastEntry {
+  int id;
+};
+using LogEntry = file::Managed<LogEntryBase, LastEntry>;
+```
+
+then we could use:
+
+```cpp
+// get metadata
+LastEntry metadata = LogEntry::file.getMeta();
+
+// set metadata
+LastEntry metadata { entry.id() };
+LogEntry::file.setMeta(metadata);
+```
+
 ### Using variants
 
 ```cpp

--- a/src/rollback.cpp
+++ b/src/rollback.cpp
@@ -15,6 +15,7 @@ auto rollback::log (
   entry.timestamp = currentTime;
   entry.content = content;
   entry.save();
+  rollback::LogEntry::file.setMeta({ entry.id() });
 }
 
 auto command::run (const command::Rollback &cmd)

--- a/src/rollback.h
+++ b/src/rollback.h
@@ -72,7 +72,10 @@ struct LogEntryBase {
 
   static constexpr const char *filename = "rollback-log";
 };
-using LogEntry = file::Managed<LogEntryBase>;
+struct LastEntry {
+  int id;
+};
+using LogEntry = file::Managed<LogEntryBase, LastEntry>;
 
 /// inserts a log entry.
 auto log (const LogEntry::Content &content) -> void;


### PR DESCRIPTION
The id of the last rollback log entry needs to be stored in case
of a potential rollback, but this information was not stored in the
original database design. This commit fixes it.

This commit also adds documentation on how to use the metadata
feature.