### PR TITLE
feat(lib): write cache for the lru cache

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -36,7 +36,7 @@ possibly some BSD), not Microsoft Windows.
   bindings build
 - `bin/get-testdata`: Downloads test points from the SJTU
   cloud drive. Only intended for members of the ACM class of
-  SJTU.
+  SJTU. Does not work on macOS.
 - `bin/run-test`: Runs a test in the test points downloaded
   by `bin/get-testdata`.
 - `bin/run-unit-test`: Runs a specific unit test. Used by

--- a/bin/get-testdata
+++ b/bin/get-testdata
@@ -1,22 +1,36 @@
 #!/bin/bash
 
+if [ Darwin = "$(uname -s)" ]; then
+  echo "This script has issues running in macOS. Please"
+  echo "download the test points manually."
+  exit 1
+fi
+
 echo -n "Enter jbox short URL: https://jbox.sjtu.edu.cn/l/"
 read url
 
 want=fee9bef90443f997d0c27683df651c33b86ad72487dbb7d54f4c21705a9221e9
 actual=$(echo -n "ticket-2022-$url" | sha256sum | cut -d ' ' -f 1)
-if [ ! $want = $actual ]; then
+if [ ! "$want" = "$actual" ]; then
   echo "invalid link"
   exit 1
 fi
 
-resid=$(curl -v "https://jbox.sjtu.edu.cn/l/$url" 2>&1 | grep -i location | cut -d / -f 7 | tr -d '\r')
-if [ -z $resid ]; then
+resid=$(curl -v "https://jbox.sjtu.edu.cn/l/$url" 2>&1 | grep -i 'location: http' | cut -d / -f 7 | tr -d '\r')
+if [ -z "$resid" ]; then
   echo "check your network"
   exit 1
 fi
 
-zipfile=$(mktemp -p /tmp ticket.XXXXXXXXXX.zip)
+function tmp () {
+  if [ Darwin = "$(uname -s)" ]; then
+    echo /tmp/ticket.zip
+  else
+    mktemp -p /tmp ticket.XXXXXXXXXX.zip
+  fi
+}
+
+zipfile=$(tmp)
 curl -L "https://jbox.sjtu.edu.cn:10081/v2/delivery/archives/$resid/" -o "$zipfile" || (echo "download failed!"; exit 1)
 
 LANG=C unzip "$zipfile" -d tests || (echo "unzip failed!"; exit 1)

--- a/bin/run-test
+++ b/bin/run-test
@@ -23,10 +23,22 @@ if [ ! -e "$exename" ]; then
 fi
 
 function tmp () {
-  mktemp -p /tmp ticket.XXXXXXXXXX
+  if [ Darwin = "$(uname -s)" ]; then
+    mktemp /tmp/ticket.XXXXXXXXXX
+  else
+    mktemp -p /tmp ticket.XXXXXXXXXX
+  fi
 }
 
-testdir="$(mktemp -d -p /tmp ticket.XXXXXXXXXX)"
+function tmpdir () {
+  if [ Darwin = "$(uname -s)" ]; then
+    mktemp -d /tmp/ticket.XXXXXXXXXX
+  else
+    mktemp -d -p /tmp/ticket.XXXXXXXXXX
+  fi
+}
+
+testdir="$(tmpdir)"
 cp "$exename" "$testdir/"
 exe="$testdir/$exename"
 cwd="$(pwd)"

--- a/lib/algorithm.h
+++ b/lib/algorithm.h
@@ -3,9 +3,6 @@
 #define TICKET_LIB_ALGORITHM_H_
 
 #include <iostream>
-#ifndef ONLINE_JUDGE
-#include <algorithm>
-#endif // ONLINE_JUDGE
 
 #include "utility.h"
 

--- a/lib/file/index.h
+++ b/lib/file/index.h
@@ -94,11 +94,11 @@ class Index<Varchar<maxLength>, Model> {
     : ptr_(ptr), tree_(filename) {}
   /// inserts an object into the index.
   auto insert (const Model &model) -> void {
-    tree_.insert(model.*ptr_.hash(), model.id());
+    tree_.insert((model.*ptr_).hash(), model.id());
   }
   /// removes an object from the index.
   auto remove (const Model &model) -> void {
-    tree_.remove(model.*ptr_.hash(), model.id());
+    tree_.remove((model.*ptr_).hash(), model.id());
   }
   /// finds one Model in the index.
   auto findOne (const Key &key) -> Optional<Model> {

--- a/lib/lru-cache_test.cpp
+++ b/lib/lru-cache_test.cpp
@@ -3,32 +3,40 @@
 #include <assert.h>
 #include <string.h>
 
-template <typename Key, int kSize>
-using Cache = ticket::LruCache<Key, kSize>;
+bool called = false;
+auto handler (int key, char *buf, int length) -> void {
+  called = true;
+}
+
+template <typename Key, int kSize, typename Callback>
+using Cache = ticket::LruCache<Key, kSize, Callback>;
 
 auto main () -> int {
-  Cache<int, 4> c;
+  Cache<int, 4, decltype(&handler)> c{handler};
   assert(!c.get(0));
   char tmp[10];
   strncpy(tmp, "hello", sizeof(tmp));
-  assert(c.upsert(0, tmp, 6));
-  assert(!c.upsert(0, tmp, 6));
-  assert(!c.upsert(0, tmp, 6));
-  assert(c.upsert(1, tmp, 6));
-  assert(c.upsert(2, tmp, 6));
+  c.upsert(0, tmp, 6);
+  c.upsert(1, tmp, 6);
+  c.upsert(2, tmp, 6);
+  c.upsert(2, tmp, 6);
   assert(strncmp((char *) *c.get(0), "hello", 6) == 0);
   strncpy(tmp, "world", sizeof(tmp));
   assert(strncmp((char *) *c.get(0), "hello", 6) == 0);
-  assert(c.upsert(0, tmp, 6));
+  c.upsert(0, tmp, 6);
   assert(strncmp((char *) *c.get(0), "world", 6) == 0);
   assert(strncmp((char *) *c.get(1), "hello", 6) == 0);
-  assert(!c.upsert(0, tmp, 6));
-  assert(c.upsert(3, tmp, 6));
-  assert(c.upsert(4, tmp, 6));
+  c.upsert(0, tmp, 6);
+  c.upsert(3, tmp, 6);
+  assert(!called);
+  c.upsert(4, tmp, 6);
+  assert(called);
+  called = false;
   assert(!c.get(2));
   c.remove(4);
   assert(!c.get(4));
-  assert(c.upsert(5, tmp, 6));
+  c.upsert(5, tmp, 6);
+  assert(!called);
   assert(c.get(0) && c.get(1) && c.get(3));
   return 0;
 }

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -78,6 +78,24 @@ class Vector {
     auto operator< (const const_iterator &rhs) const -> bool {
       return **this < *rhs;
     }
+    auto operator> (const iterator &rhs) const -> bool {
+      return rhs < *this;
+    }
+    auto operator> (const const_iterator &rhs) const -> bool {
+      return rhs < *this;
+    }
+    auto operator<= (const iterator &rhs) const -> bool {
+      return !(*this > rhs);
+    }
+    auto operator<= (const const_iterator &rhs) const -> bool {
+      return !(*this > rhs);
+    }
+    auto operator>= (const iterator &rhs) const -> bool {
+      return !(*this < rhs);
+    }
+    auto operator>= (const const_iterator &rhs) const -> bool {
+      return !(*this < rhs);
+    }
     friend class const_iterator;
     friend class Vector;
   };
@@ -131,6 +149,24 @@ class Vector {
     }
     auto operator< (const const_iterator &rhs) const -> bool {
       return **this < *rhs;
+    }
+    auto operator> (const iterator &rhs) const -> bool {
+      return rhs < *this;
+    }
+    auto operator> (const const_iterator &rhs) const -> bool {
+      return rhs < *this;
+    }
+    auto operator<= (const iterator &rhs) const -> bool {
+      return !(*this > rhs);
+    }
+    auto operator<= (const const_iterator &rhs) const -> bool {
+      return !(*this > rhs);
+    }
+    auto operator>= (const iterator &rhs) const -> bool {
+      return !(*this < rhs);
+    }
+    auto operator>= (const const_iterator &rhs) const -> bool {
+      return !(*this < rhs);
     }
     friend class iterator;
     friend class Vector;


### PR DESCRIPTION
Previously, the LRU cache did not cache write operations. Data is
written to the file when the set function is executed. This caused
a lot of unnecessary writes, especially in hot spots. This commit
changes the LRU cache so that the data is only written to the file
when the entry is cleared from the cache.